### PR TITLE
clean up main data generation and make compatible with pytheus version 1.2.21

### DIFF
--- a/data_main/generate_data.py
+++ b/data_main/generate_data.py
@@ -1,41 +1,106 @@
-import numpy as np
-import itertools
-# from html_plot import plot_graph
-from fancy_classes import Graph
-from valpos_res import val_verts_0, val_verts_1
+"""
+Dataset generator for graph-based quantum states.
 
+What it does
+------------
+1) Reads pre-generated topologies from `topologies/<CODELEN>_<DEGREE>.txt`
+2) Samples random colors/weights and constructs graphs for N in {0, 1, 2}
+3) Validates graphs, builds states (unnormalized), and tokenizes code/state strings
+4) Appends samples into an HDF5 file with fixed shapes
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
 import os
 import time
-import json
+from typing import Dict, Iterable, List, Sequence, Tuple
+
 import h5py
+import numpy as np
 
-from generate_topologies import generate_graph, pos_0_temp_list, pos_1_temp_list
+from pytheus.fancy_classes import Graph
+from generate_topologies import generate_graph
+from valpos_res import val_verts_0, val_verts_1
 
-sign_dict = {-1:'-', 1:'+'}
-sign_dict_inv = {'-':-1, '+':1}
-positions = 'abcdefgh'
-position_dict = {i:positions[i] for i in range(8)}
-modes = 'xyz'
-mode_dict = {i:modes[i] for i in range(3)}
 
-def build_state_string(state):
-    # write state as string
-    str_state = ''
-    for key in state.kets:
-        weight = state[key]
+# =========================
+# Defaults for CLI
+# =========================
+
+DEFAULT_MAX_TOKS: int = 1024
+DEFAULT_NUM_SAMPLES: int = 50_000
+DEFAULT_BATCH_SIZE: int = 1_000
+
+
+# =========================
+# Pretty maps for state strings
+# =========================
+
+_POSITIONS = "abcdefgh"
+_MODES = "xyz"
+position_dict: Dict[int, str] = {i: _POSITIONS[i] for i in range(8)}
+mode_dict: Dict[int, str] = {i: _MODES[i] for i in range(3)}
+
+# vertex counts for N in {0, 1, 2}
+VERTEX_NUMS = [4, 6, 8]
+
+
+# =========================
+# Helpers
+# =========================
+
+def _coalesce_edges_and_reject_zeros(
+    edges5: Iterable[Sequence[int]],
+    strict_zero: bool = True,
+) -> List[Tuple[int, int, int, int, int]]:
+    """
+    Deterministic semantics for duplicate edges:
+      - Sum weights for duplicate (u, v, cu, cv).
+      - If strict_zero is True, raise if any aggregated weight becomes 0.
+      - Otherwise, drop zero-weight edges.
+
+    Input:
+        edges5: iterable of 5-tuples (u, v, cu, cv, w)
+
+    Returns:
+        List of 5-tuples (u, v, cu, cv, w) with aggregated, non-zero weights.
+    """
+    acc: Dict[Tuple[int, int, int, int], int] = {}
+    for e in edges5:
+        key = tuple(e[:4])  # type: ignore[index]
+        w = int(e[4])       # type: ignore[index]
+        acc[key] = acc.get(key, 0) + w
+
+    zeros = [k for k, w in acc.items() if w == 0]
+    if zeros and strict_zero:
+        # Caller can catch and mark the candidate invalid.
+        raise ValueError("Zero-weight edge after aggregation.")
+
+    return [(*k, w) for k, w in acc.items() if w != 0]
+
+
+def build_state_string(state) -> str:
+    """
+    Build a compact, human-readable state string like: '+2[axbycxdy]+1[aybxcxdy]'
+    """
+    s = []
+    for ket in state.kets:
+        weight = state[ket]
         if weight != 0:
-            ket = [position_dict[el[0]]+mode_dict[el[1]] for el in key]
-            ket = '['+''.join(ket)+']'
-            if weight > 0:
-                str_state += '+'
-            str_state += str(weight) + str(ket)
-    return str_state
+            pretty = "".join(position_dict[i] + mode_dict[j] for (i, j) in ket)
+            s.append(("+" if weight > 0 else "") + f"{weight}[{pretty}]")
+    return "".join(s)
 
-def tokenize_string(input_str, token_dict):
-    indices = []
+
+def tokenize_string(input_str: str, token_dict: Dict[str, int]) -> np.ndarray:
+    """
+    Greedy tokenization by prefix matching. Adds <SOS> at start and <EOS> at end.
+    """
+    indices: List[int] = [token_dict["<SOS>"]]
     i = 0
-    #sos token
-    indices.append(token_dict['<SOS>'])
     while i < len(input_str):
         found = False
         for token, index in token_dict.items():
@@ -45,262 +110,352 @@ def tokenize_string(input_str, token_dict):
                 found = True
                 break
         if not found:
-            i += 1  # Move to the next character if no matching token is found
-            print('unknown token found')
-            print(input_str[i-1])
-            print(input_str[i-2:i+2])
-            #raise exception
-            raise Exception('unknown token found')
-    #eos token
-    indices.append(token_dict['<EOS>'])
-    return np.array(indices,dtype='int8')
-
-def detokenize_indices(indices, token_dict):
-    # Create a reverse mapping from indices to tokens
-    reverse_dict = {index: token for token, index in token_dict.items()}
-    
-    #remove padding tokens
-    indices = [index for index in indices if index != token_dict['<PAD>']]
-
-    # Convert the list of indices to the corresponding tokens
-    output_str = ''.join(reverse_dict.get(index, '') for index in indices)
-    
-    return output_str
+            print("[tokenize] Unknown token at position", i)
+            print(input_str[i - 1 : i + 3])
+            raise Exception("unknown token found")
+    indices.append(token_dict["<EOS>"])
+    return np.array(indices, dtype="int8")
 
 
-if __name__ == '__main__':
-    #task id
-    import argparse
+def detokenize_indices(indices: Iterable[int], token_dict: Dict[str, int]) -> str:
+    """
+    Reverse of tokenize_string(), ignoring <PAD>.
+    """
+    reverse = {v: k for k, v in token_dict.items()}
+    return "".join(reverse.get(ix, "") for ix in indices if ix != token_dict["<PAD>"])
+
+
+def build_graph_and_state(
+    layer_0: Sequence[Sequence[int]],
+    layer_1: Sequence[Sequence[int]],
+    N: int,
+    layer_0_extra: Sequence[Sequence[int]],
+    layer_1_extra: Sequence[Sequence[int]],
+):
+    """
+    Construct graph for a given N, coalesce duplicate edges, and return (Graph, state)
+    with unnormalized amplitudes. Any failure is raised to the caller.
+    """
+    graph = generate_graph(layer_0, layer_1, N, layer_0_extra, layer_1_extra)
+    graph = [tuple(int(el) for el in edge) for edge in graph]  # (u, v, cu, cv, w)
+    graph = _coalesce_edges_and_reject_zeros(graph, strict_zero=True)
+
+    g = Graph(graph)
+    # Some pytheus internals (e.g., state catalog tensorization) may rely on complete_graph_edges; set it explicitly.
+    g.complete_graph_edges = list(g.edges)
+    # Leave amplitudes unnormalized; the dataset/pipeline expects integer amplitudes. In newer pytheus versions, getState() normalizes by default, causing float amplitudes and issues with tokenization.
+    g.getState(normalize=False)
+    return g, g.state
+
+
+def append_batch_to_h5(
+    filename: str,
+    data_buffer: List[Dict[str, np.ndarray]],
+    max_toks: int,
+) -> None:
+    """
+    Append the current buffer to an HDF5 file, creating datasets on first write.
+    Asserts that sequences do not exceed max_toks.
+    """
+    maxshape_dict = {
+        "code": (None, max_toks),
+        "state": (None, max_toks),
+        "topology_ind": (None, 2),
+        "line_count": (None, 2),
+        "num_kets": (None, 3),
+        "num_zero_kets": (None, 3),
+        "num_pms": (None, 3),
+        "degrees_list": (None, 3, 8),
+    }
+
+    with h5py.File(filename, "a") as f:
+        # Lazily create datasets
+        for key in data_buffer[0]:
+            if key not in f:
+                init_shape = (0, *maxshape_dict[key][1:])
+                print(f"[h5] creating dataset '{key}' with shape {init_shape}")
+                f.create_dataset(key, init_shape, maxshape=maxshape_dict[key], dtype="int8")
+
+        # Resize and write
+        n_new = len(data_buffer)
+        for key in data_buffer[0]:
+            f[key].resize((f[key].shape[0] + n_new), axis=0)
+            if key in ["code", "state"]:
+                padded = np.zeros((n_new, max_toks), dtype="int8")
+                for i, sample in enumerate(data_buffer):
+                    seq = sample[key]
+                    assert len(seq) <= max_toks, (
+                        f"Sample sequence for '{key}' longer than max_toks: "
+                        f"{len(seq)} > {max_toks}"
+                    )
+                    padded[i, : len(seq)] = seq
+                f[key][-n_new:] = padded
+            else:
+                arr = np.array([sample[key] for sample in data_buffer], dtype="int8")
+                f[key][-n_new:] = arr
+
+
+# =========================
+# Main
+# =========================
+
+def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument('--task_id', type=int, default=0)
+    parser.add_argument("--task_id", type=int, default=0, help="Task index for distributed runs.")
+    parser.add_argument(
+        "--verbose-invalid",
+        action="store_true",
+        help="If set, print reasons when a candidate graph/state is rejected.",
+    )
+    parser.add_argument(
+        "--num-samples",
+        type=int,
+        default=DEFAULT_NUM_SAMPLES,
+        help=f"Total samples to produce (default: {DEFAULT_NUM_SAMPLES}).",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        help=f"Samples per HDF5 write (default: {DEFAULT_BATCH_SIZE}).",
+    )
+    parser.add_argument(
+        "--max-toks",
+        type=int,
+        default=DEFAULT_MAX_TOKS,
+        help=f"Maximum token sequence length (default: {DEFAULT_MAX_TOKS}).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Random seed for reproducibility (default: None).",
+    )
     args = parser.parse_args()
+
     node_id = args.task_id
-    local_id = os.environ.get('SLURM_LOCALID', 0)
-    print(f"Local Task ID: {local_id}")
-    SLURMID = str(32*int(node_id) + int(local_id))
+    local_id = os.environ.get("SLURM_LOCALID", 0)
+    print(f"[init] Local Task ID: {local_id}")
+    SLURMID = str(32 * int(node_id) + int(local_id))
 
-    token_dict = json.load(open('tok.json'))
+    # Seed control
+    if args.seed is not None:
+        np.random.seed(args.seed)
+        print(f"[init] numpy RNG seeded with {args.seed}")
 
-    def build_config_dict(ind):
+    # tokens
+    token_dict = json.load(open("tok.json"))
+
+    def build_config_dict(ind: int):
         possible_values = {
-            'CODELEN': ['SHORT', 'LONG'],
-            'DEGREE': ['DEG1', 'DEG2'],
-            'DIMENSION': ['2D', '3D'],
-            'EDGEWEIGHT': ['WEIGHTED', 'UNWEIGHTED'],
-            'MAX_KETS': ['8-16-32', '6-6-6']
+            "CODELEN": ["SHORT", "LONG"],
+            "DEGREE": ["DEG1", "DEG2"],
+            "DIMENSION": ["2D", "3D"],
+            "EDGEWEIGHT": ["WEIGHTED", "UNWEIGHTED"],
+            "MAX_KETS": ["8-16-32", "6-6-6"],
         }
-        #all possible combinations
         all_combinations = list(itertools.product(*possible_values.values()))
-        print(f'number of combinations: {len(all_combinations)}')
-        print(f'chosen index: {ind} of {len(all_combinations)} (possibly applied modulo')
-        #get the combination
-        combination = all_combinations[ind%len(all_combinations)]
-        #create the dictionary
-        config_dict = {key:combination[i] for i,key in enumerate(possible_values.keys())}
-        return config_dict, len(all_combinations)
-    
-    config_dict, num_combinations = build_config_dict(int(SLURMID))
-    FILE_IND = int(SLURMID)//num_combinations
-    # config_dict = {
-    #         'CODELEN': 'LONG',
-    #         'DEGREE': 'DEG2',
-    #         'DIMENSION': '2D',
-    #         'EDGEWEIGHT': 'UNWEIGHTED',
-    #         'MAX_KETS': '8-16-32'
-    #     }
-    globals().update(config_dict)
-    topology_dict = {('LONG', 'DEG2'): 0, ('SHORT', 'DEG2'): 1, ('LONG', 'DEG1'): 2, ('SHORT', 'DEG1'): 3}
-    topology_letter = topology_dict[(CODELEN, DEGREE)]
-    print(f'topology letter: {topology_letter}')
-    MAX_KETS = tuple([int(val) for val in MAX_KETS.split('-')])
+        print(f"[config] number of combinations: {len(all_combinations)}")
+        print(f"[config] chosen index: {ind} of {len(all_combinations)} (applied modulo if needed)")
+        combination = all_combinations[ind % len(all_combinations)]
+        cfg = {key: combination[i] for i, key in enumerate(possible_values.keys())}
+        return cfg, len(all_combinations)
 
-    DIR_NAME = 'data'
-    #join the config values to create the directory name
-    TOP_FILENAME = 'topologies/'+CODELEN+'_'+DEGREE+'.txt'
-    OUT_DIR = DIR_NAME +'/'+'_'.join([str(val) for val in config_dict.values()])
+    config_dict, num_combinations = build_config_dict(int(SLURMID))
+    FILE_IND = int(SLURMID) // num_combinations
+    globals().update(config_dict)
+
+    topology_dict = {("LONG", "DEG2"): 0, ("SHORT", "DEG2"): 1, ("LONG", "DEG1"): 2, ("SHORT", "DEG1"): 3}
+    topology_letter = topology_dict[(CODELEN, DEGREE)]
+    MAX_KETS_tuple = tuple(int(v) for v in config_dict["MAX_KETS"].split("-"))
+
+    # IO setup
+    DIR_NAME = "data"
+    TOP_FILENAME = f"topologies/{CODELEN}_{DEGREE}.txt"
+    OUT_DIR = f"{DIR_NAME}/{'_'.join(str(v) for v in config_dict.values())}"
     if FILE_IND == 0 and not os.path.exists(OUT_DIR):
         os.makedirs(OUT_DIR)
-    time.sleep(3)
-    FILE_NAME = OUT_DIR+'/'+str(FILE_IND)+'.h5'
-    LOG_FILE_PATH = OUT_DIR+'/'+str(FILE_IND)+'.txt'
-    print(f'file name: {FILE_NAME}')
-    print(f'topology file: {TOP_FILENAME}')
-    with h5py.File(f'{FILE_NAME}', 'a') as f:
-        #save token dict, config dict and val_verts to the file
-        f.attrs['token_dict'] = json.dumps(token_dict)
-        f.attrs['config_dict'] = json.dumps(config_dict)
-        f.attrs['val_verts_0'] = json.dumps(val_verts_0)
-        f.attrs['val_verts_1'] = json.dumps(val_verts_1)
+    FILE_NAME = f"{OUT_DIR}/{FILE_IND}.h5"
+    LOG_FILE_PATH = f"{OUT_DIR}/{FILE_IND}.txt"
 
-    NUM_SAMPLES = 50_000
+    print("[init] configuration:", config_dict)
+    print(f"[init] topology file: {TOP_FILENAME}")
+    print(f"[init] output H5:      {FILE_NAME}")
+    print(f"[init] log file:       {LOG_FILE_PATH}")
+    print(f"[init] samples target: {args.num_samples}, batch size: {args.batch_size}, max toks: {args.max_toks}")
+    print(f"[hint] config is chosen by SLURMID mod {num_combinations} combinations.")
 
-    ranges = ['N']
-    VERTEX_NUMS = [4, 6, 8]
-    if EDGEWEIGHT == 'WEIGHTED':
-        WEIGHTS = [-1,1]
-    else:
-        WEIGHTS = [1]
+    # Store run metadata in the H5 file attributes
+    with h5py.File(FILE_NAME, "a") as f:
+        f.attrs["token_dict"] = json.dumps(token_dict)
+        f.attrs["config_dict"] = json.dumps(config_dict)
+        f.attrs["val_verts_0"] = json.dumps(val_verts_0)
+        f.attrs["val_verts_1"] = json.dumps(val_verts_1)
+
+    # sampling constants
+    WEIGHTS = [-1, 1] if config_dict["EDGEWEIGHT"] == "WEIGHTED" else [1]
     REPS = 100
 
-    used_topologies = []
+    used_topologies: List[int] = []
     valid_codes = 0
-    data_buffer = []
-    tt = time.time()
-    max_src = 0
-    max_tgt = 0
-    tt = time.time()
-    while valid_codes < NUM_SAMPLES:
-        #read data/code.txt
-        with open(TOP_FILENAME, 'r') as file:
-            data = file.read()
-            for line_ind, line in enumerate(data.split('\n')):
-                valid = False
-                # print(f'line {line_ind}')
-                if DIMENSION == '3D':
-                    COLORS = [0,1,2]
-                elif DIMENSION == '2D':
-                    #choose 2 colors randomly from 0,1,2
-                    COLORS = np.random.choice([0,1,2], 2, replace=False)  
+    data_buffer: List[Dict[str, np.ndarray]] = []
+    t0 = time.time()
 
-                for i in range(REPS):
-                    if line == '':
-                        continue
-                    # print(line)
-                    #split at '|'
-                    parts = line.split('|')
-                    # print(parts)
-                    layer_0 = eval(parts[0])
-                    layer_1 = eval(parts[1])
-                    #shuffle the layers
-                    np.random.shuffle(layer_0)
-                    np.random.shuffle(layer_1)
+    print("[run] starting main loop…")
+    while valid_codes < args.num_samples:
+        with open(TOP_FILENAME, "r") as fh:
+            data = fh.read()
 
-                    #shuffle within the layers
-                    for layer in [layer_0, layer_1]:
-                        for posvals in layer:
-                            np.random.shuffle(posvals)
+        for line_ind, line in enumerate(data.split("\n")):
+            if valid_codes >= args.num_samples:
+                break
+            if line == "":
+                continue
 
-                    #adding random colors and weights
-                    layer_0_extra = [[np.random.choice(COLORS), np.random.choice(COLORS), np.random.choice(WEIGHTS)] for _ in range(len(layer_0))]
-                    layer_1_extra = [[np.random.choice(COLORS), np.random.choice(COLORS), np.random.choice(WEIGHTS)] for _ in range(len(layer_1))]
+            # Choose color set per line
+            if config_dict["DIMENSION"] == "3D":
+                COLORS = [0, 1, 2]
+            else:  # "2D"
+                COLORS = list(np.random.choice([0, 1, 2], 2, replace=False))
 
-                    valid = True
+            valid = False
+            for _ in range(REPS):
+                # Parse and shuffle layers
+                parts = line.split("|")
+                layer_0 = eval(parts[0])
+                layer_1 = eval(parts[1])
+
+                np.random.shuffle(layer_0)
+                np.random.shuffle(layer_1)
+
+                for layer in (layer_0, layer_1):
+                    for posvals in layer:
+                        np.random.shuffle(posvals)
+
+                # random colors/weights per edge
+                layer_0_extra = [[np.random.choice(COLORS), np.random.choice(COLORS), np.random.choice(WEIGHTS)]
+                                 for _ in range(len(layer_0))]
+                layer_1_extra = [[np.random.choice(COLORS), np.random.choice(COLORS), np.random.choice(WEIGHTS)]
+                                 for _ in range(len(layer_1))]
+
+                valid = True
+                # quick validation pass for N = 0, 1, 2
+                for N in range(3):
+                    try:
+                        g, state = build_graph_and_state(
+                            layer_0, layer_1, N, layer_0_extra, layer_1_extra
+                        )
+                    except Exception as e:
+                        if args.verbose_invalid:
+                            print(f"[validate] N={N} invalid graph/state (reason: {e})")
+                        valid = False
+                        break
+
+                    non_zero = [amp for amp in state.amplitudes if amp != 0]
+                    if len(non_zero) > MAX_KETS_tuple[N] or len(non_zero) == 0:
+                        valid = False
+                        break
+
+                if valid:
+                    valid_codes += 1
+                    used_topologies.append(line_ind)
+
+                    # Build per-N stats and state strings
+                    state_str_parts: List[str] = []
+                    topology_ind = np.array([topology_letter, line_ind], dtype="int8")
+                    line_count = np.array([len(layer_0), len(layer_1)], dtype="int8")
+
+                    num_kets = np.zeros(3, dtype="int8")
+                    num_zero_kets = np.zeros(3, dtype="int8")
+                    num_pms = np.zeros(3, dtype="int8")
+                    degrees_list = np.zeros((3, 8), dtype="int8")
+
                     for N in range(3):
-                        # print(N)
-                        graph = generate_graph(layer_0, layer_1, N, layer_0_extra, layer_1_extra)
-                        graph = [tuple([int(el) for el in edge]) for edge in graph]
                         try:
-                            g = Graph(graph)
-                            g.getState()
-                        except:
+                            g, state = build_graph_and_state(
+                                layer_0, layer_1, N, layer_0_extra, layer_1_extra
+                            )
+                        except Exception as e:
+                            if args.verbose_invalid:
+                                print(f"[build] N={N} failed (reason: {e})")
                             valid = False
                             break
 
-                        non_zero_amps = [amp for amp in g.state.amplitudes if amp != 0]
-                        if len(non_zero_amps) > MAX_KETS[N] or len(non_zero_amps) == 0:
-                            valid = False
-                            break
+                        num_kets[N] = len([amp for amp in state.amplitudes if amp != 0])
+                        num_zero_kets[N] = len([amp for amp in state.amplitudes if amp == 0])
+                        num_pms[N] = len(g.perfect_matchings)
 
-                    if valid:
-                        valid_codes += 1
-                        # print(f'CODE {valid_codes} FOUND',end='\r')
-                        state_str = ''
+                        verts = sum([list(edge[:2]) for edge in g.edges], [])
+                        _, degrees = np.unique(verts, return_counts=True)
+                        degrees = np.sort(degrees)
+                        degrees_list[N, : (4 + 2 * N)] = degrees
 
-                        topology_ind = np.array([topology_letter, line_ind], dtype='int8')
-                        used_topologies.append(line_ind)
-                        line_count = np.array([len(layer_0),len(layer_1)], dtype='int8')
+                        state_str_parts.append(build_state_string(state))
 
-                        num_kets = np.zeros(3, dtype='int8')
-                        num_zero_kets = np.zeros(3, dtype='int8')
-                        num_pms = np.zeros(3, dtype='int8')
-                        degrees_list = np.zeros((3, 8), dtype='int8')
-                        for N in range(3):
-                            graph = generate_graph(layer_0, layer_1, N, layer_0_extra, layer_1_extra)
-                            graph = [tuple([int(el) for el in edge]) for edge in graph]
-                            # print(graph)
-                            g = Graph(graph)
-                            g.getState()
-                            num_kets[N] = len([amp for amp in g.state.amplitudes if amp != 0])
-                            num_zero_kets[N] = len([amp for amp in g.state.amplitudes if amp == 0])
-                            num_pms[N] = len(g.perfect_matchings)
+                    if not valid:
+                        continue
 
-                            verts = sum([list(edge[:2]) for edge in g.edges], [])
-                            _, degrees = np.unique(verts, return_counts=True)
-                            #sort the degrees
-                            degrees = np.sort(degrees)
-                            degrees_list[N,:(4+2*N)] = degrees
-                        
-                            state_str += build_state_string(g.state) + '|'
-                            # g = Graph(graph)
-                            # plot_graph(graph, f'graph_{N}.html')
-                        state_str = state_str[:-1]
-                        # print(state_str)
+                    state_str = "|".join(state_str_parts)
 
-                        code_str = ''
-                        for pos, extra in zip(layer_0, layer_0_extra):
-                            code_str += f'e({val_verts_0[pos[0]]},{val_verts_0[pos[1]]},{extra[0]},{extra[1]},{extra[2]})\n'
-                        code_str += 'for ii in range(N):\n'
-                        for pos, extra in zip(layer_1, layer_1_extra):
-                            code_str += f'    e({val_verts_1[pos[0]]},{val_verts_1[pos[1]]},{extra[0]},{extra[1]},{extra[2]})\n'
+                    # produce a code string describing the sampled program
+                    code_lines = []
+                    for pos, extra in zip(layer_0, layer_0_extra):
+                        code_lines.append(
+                            f"e({val_verts_0[pos[0]]},{val_verts_0[pos[1]]},{extra[0]},{extra[1]},{extra[2]})"
+                        )
+                    code_lines.append("for ii in range(N):")
+                    for pos, extra in zip(layer_1, layer_1_extra):
+                        code_lines.append(
+                            f"    e({val_verts_1[pos[0]]},{val_verts_1[pos[1]]},{extra[0]},{extra[1]},{extra[2]})"
+                        )
+                    code_str = "\n".join(code_lines)
 
-                        # print(code_str)
+                    # tokenize
+                    code_tok = tokenize_string(code_str, token_dict)
+                    state_tok = tokenize_string(state_str, token_dict)
 
-                        code = tokenize_string(code_str, token_dict)
-                        state = tokenize_string(state_str, token_dict)
-
-                        sample = {
-                            'code': code,
-                            'state': state,
-                            'topology_ind': topology_ind,
-                            'line_count': line_count,
-                            'num_kets': num_kets,
-                            'num_zero_kets': num_zero_kets,
-                            'num_pms': num_pms,
-                            'degrees_list': degrees_list
-                        }
-
-                        # print(sample)
-
-                        data_buffer.append(sample)
-                        break
-                if len(data_buffer) >= 1000:
-                    # print(sample)
-                    MAX_TOKS = 1024
-                    maxshape_dict = {
-                        'code': (None, MAX_TOKS),
-                        'state': (None, MAX_TOKS),
-                        'topology_ind': (None,2),
-                        'line_count': (None, 2),
-                        'num_kets': (None, 3),
-                        'num_zero_kets': (None, 3),
-                        'num_pms': (None, 3),
-                        'degrees_list': (None, 3, 8)
+                    sample = {
+                        "code": code_tok,
+                        "state": state_tok,
+                        "topology_ind": topology_ind,
+                        "line_count": line_count,
+                        "num_kets": num_kets,
+                        "num_zero_kets": num_zero_kets,
+                        "num_pms": num_pms,
+                        "degrees_list": degrees_list,
                     }
+                    data_buffer.append(sample)
 
-                    #write to txt file
-                    time_elapsed = time.time() - tt
-                    unique_topologies = len(set(used_topologies))
-                    with open(LOG_FILE_PATH, 'a') as file:
-                        file.write(f'{valid_codes} samples written to file in {time_elapsed} seconds, {round((valid_codes/(time_elapsed/3600))/1000,2)}k samples per hour, {unique_topologies} unique topologies\n')
-                    #create the dataset if it does not exist
-                    with h5py.File(FILE_NAME, 'a') as f:
-                        for key, val in data_buffer[0].items():
-                            if key not in f:
-                                init_shape = (0, *maxshape_dict[key][1:])
-                                print(f'creating dataset {key} with shape {init_shape}')
-                                f.create_dataset(key, init_shape, maxshape=maxshape_dict[key], dtype='int8')
-                            # print(key, val, val.shape)
-                            f[key].resize((f[key].shape[0] + len(data_buffer)), axis = 0)
-                            #padding
-                            if key in ['code', 'state']:
-                                data = np.zeros((len(data_buffer), MAX_TOKS), dtype='int8')
-                                for i, sample in enumerate(data_buffer):
-                                    data[i,:len(sample[key])] = sample[key]
-                            else:
-                                data = np.array([sample[key] for sample in data_buffer], dtype='int8')
-                            f[key][-len(data_buffer):] = data
+                    # user-friendly progress echo
+                    if valid_codes % 200 == 0:
+                        elapsed = time.time() - t0
+                        rate_kph = (valid_codes / (elapsed / 3600)) / 1000 if elapsed > 0 else 0.0
+                        print(f"[progress] {valid_codes}/{args.num_samples} samples | "
+                              f"{elapsed:.1f}s elapsed | {rate_kph:.2f}k samples/hr")
 
-                    data_buffer = []
-                    if valid_codes >= NUM_SAMPLES:
-                        break
-    print('DONE')
+                    break  # break REPS loop after a valid sample
+
+            # Batch flush
+            if len(data_buffer) >= args.batch_size:
+                elapsed = time.time() - t0
+                unique_topologies = len(set(used_topologies))
+                with open(LOG_FILE_PATH, "a") as logf:
+                    logf.write(
+                        f"{valid_codes} samples written in {elapsed:.1f}s, "
+                        f"{(valid_codes/(elapsed/3600))/1000:.2f}k samples/hr, "
+                        f"{unique_topologies} unique topologies\n"
+                    )
+                append_batch_to_h5(FILE_NAME, data_buffer, max_toks=args.max_toks)
+                print(f"[h5] wrote batch of {len(data_buffer)} (total {valid_codes})")
+                data_buffer = []
+
+    # Final flush if needed
+    if data_buffer:
+        append_batch_to_h5(FILE_NAME, data_buffer, max_toks=args.max_toks)
+        print(f"[h5] wrote final batch of {len(data_buffer)}")
+
+    print("[done] generation complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/data_main/generate_topologies.py
+++ b/data_main/generate_topologies.py
@@ -192,7 +192,7 @@ if __name__ == '__main__':
                 valid = True
         print('CODE FOUND')
         #save layer_0, layer_1 to file
-        with open(os.path.join(save_dir, f'topology_{config['filename']}.txt'), 'a') as f:
+        with open(os.path.join(save_dir, f"{config['filename']}.txt"), 'a') as f:
             layer_0 = [list(edge) for edge in layer_0]
             layer_1 = [list(edge) for edge in layer_1]
             f.write(f'{layer_0}|{layer_1}\n')

--- a/data_main/generate_topologies.py
+++ b/data_main/generate_topologies.py
@@ -1,72 +1,109 @@
-import numpy as np
-import itertools
-# from html_plot import plot_graph
-from pytheus.fancy_classes import Graph
-from valpos_res import val_verts_0, val_verts_1
+"""
+Topology generator for pytheus-based experiments.
 
+What it does
+------------
+1) Randomly samples candidate edge sets for two layers.
+2) For each N in {0, 1, 2}, builds the corresponding graph instance (positions expanded)
+   and validates it via:
+   - no self-loops
+   - vertex count and minimum degree
+   - every edge belongs to at least one perfect matching
+3) On success, appends the (layer_0 | layer_1) description to a file in `topologies/`.
+"""
+
+from __future__ import annotations
+
+import argparse
 import os
 import time
+from typing import List, Sequence
+
+import numpy as np
+import pytheus.theseus as th
+
+from valpos_res import val_verts_0, val_verts_1
 
 
-# layer 0:
-#     * verts: (0,1,2,3) + (0,1,2)*N
-#     * colors: (x,y,z)
-#     * weights: (1,-1)
+# =========================
+# Constants
+# =========================
 
-# layer 1:
-#     * verts: (0,1,2,3,4) + (0,1,2)*N + (0,1,2)*ii
-#     * colors: (x,y,z)
-#     * weights: (1,-1)
-
-ranges = ['N']
-
-LEVEL = [0,1,2]
+# Vertex counts for N in {0, 1, 2}
 VERTEX_NUMS = [4, 6, 8]
 
-pos_0_temp_list = []
+
+# =========================
+# Precomputed position tables
+# =========================
+
+# Expand val_verts_* string templates into concrete integer positions for each N.
+pos_0_temp_list: List[List[int]] = []
 for N in range(3):
-    pos_0_temp_list.append([eval(pos.replace('N', str(N))) for pos in val_verts_0])
-    
-pos_1_temp_list = []
+    pos_0_temp_list.append([eval(pos.replace("N", str(N))) for pos in val_verts_0])
+
+pos_1_temp_list: List[List[List[int]]] = []
 for N in range(3):
-    entry_base = [pos.replace('N', str(N)) for pos in val_verts_1]
-    pos1_temp_list_2 = []
+    entry_base = [pos.replace("N", str(N)) for pos in val_verts_1]
+    pos1_temp_list_2: List[List[int]] = []
     for ii in range(N):
-        entry = [eval(pos.replace('ii', str(ii))) for pos in entry_base]
+        entry = [eval(pos.replace("ii", str(ii))) for pos in entry_base]
         pos1_temp_list_2.append(entry)
     pos_1_temp_list.append(pos1_temp_list_2)
-        
 
 
-def generate_graph(layer_0, layer_1, N, layer_0_extra = None, layer_1_extra = None):
+# =========================
+# Helpers
+# =========================
+
+def generate_graph(
+    layer_0: Sequence[Sequence[int]],
+    layer_1: Sequence[Sequence[int]],
+    N: int,
+    layer_0_extra: Sequence[Sequence[int]] | None = None,
+    layer_1_extra: Sequence[Sequence[int]] | None = None,
+) -> List[List[int]]:
+    """
+    Expand abstract layer indices into concrete edges for a given N.
+
+    Each edge is [u, v] here (no colors/weights in this generator).
+    """
     pos_0_temp = pos_0_temp_list[N]
 
-    graph = []
+    graph: List[List[int]] = []
     if layer_0_extra is None:
-        layer_0_extra = [[]]*len(layer_0)
+        layer_0_extra = [[]] * len(layer_0)
     if layer_1_extra is None:
-        layer_1_extra = [[]]*len(layer_1)
+        layer_1_extra = [[]] * len(layer_1)
 
     for line, extra in zip(layer_0, layer_0_extra):
         edge = [pos_0_temp[line[0]], pos_0_temp[line[1]]]
         edge = edge + extra
         graph.append(edge)
+
     for line, extra in zip(layer_1, layer_1_extra):
-        for ii in range(N): #CHECK THIS WHEN CHANGING RANGES
+        for ii in range(N):  # this assumes that for-loops in codes are always over range(N). For more generality, we would need to pass in the loop ranges.
             pos1_temp2 = pos_1_temp_list[N][ii]
-            edge =[pos1_temp2[line[0]], pos1_temp2[line[1]]]
+            edge = [pos1_temp2[line[0]], pos1_temp2[line[1]]]
             edge = edge + extra
             graph.append(edge)
-    return graph   
+    return graph
 
 
-def check_self_loops(graph):
+def check_self_loops(graph: Sequence[Sequence[int]]) -> bool:
+    """Return True if no edge is a self-loop."""
     for edge in graph:
         if edge[0] == edge[1]:
             return False
     return True
 
-def check_degree_and_vertcount(graph,vertex_count, min_degree=2):
+
+def check_degree_and_vertcount(
+    graph: Sequence[Sequence[int]],
+    vertex_count: int,
+    min_degree: int = 2,
+) -> bool:
+    """Check vertex count and that all vertices have degree >= min_degree."""
     verts = sum(graph, [])
     verts, degrees = np.unique(verts, return_counts=True)
     if len(verts) != vertex_count:
@@ -75,128 +112,154 @@ def check_degree_and_vertcount(graph,vertex_count, min_degree=2):
         return False
     return True
 
-def check_pms(graph):
-    graph_temp = [tuple(edge+[0,0]) for edge in graph]
-    g = Graph(graph_temp)
-    pm_edges = []
-    for pm in g.perfect_matchings:
-        pm_edges += pm
-    pm_edges = list(set(pm_edges))
-    for edge in g.edges:
-        if edge not in pm_edges:
-            return False
-    return True
 
-if __name__ == '__main__':
-    #task id
-    import argparse
+def check_pms(graph: Sequence[Sequence[int]]) -> bool:
+    """
+    Check that every edge participates in at least one perfect matching.
+
+    Converts each edge to a 4-tuple (u, v, cu, cv) with zero colors.
+    """
+    edges4 = [tuple(edge + [0, 0]) for edge in graph]
+    pms = th.findPerfectMatchings(edges4)
+    pm_edges = {e for pm in pms for e in pm}
+    return all(e in pm_edges for e in edges4)
+
+
+# =========================
+# Main
+# =========================
+
+def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument('--task_id', type=int, default=0)
-    parser.add_argument('--config', type=str, default='A')
+    parser.add_argument("--task_id", type=int, default=0, help="Task index for distributed runs.")
+    parser.add_argument("--config", type=str, default="A", choices=list("ABCD"), help="Which config to use.")
+    parser.add_argument(
+        "--verbose-invalid",
+        action="store_true",
+        help="If set, print reasons when a candidate graph is rejected.",
+    )
+    parser.add_argument(
+        "--progress-every",
+        type=int,
+        default=100_000,
+        help="Print a progress line every N attempts (default: 100000).",
+    )
     args = parser.parse_args()
-    node_id = args.task_id
-    local_id = os.environ.get('SLURM_LOCALID', 0)
-    print(f"Local Task ID: {local_id}")
-    SLURMID = str(32*int(node_id) + int(local_id))
 
-    save_dir = 'topologies'
+    node_id = args.task_id
+    local_id = os.environ.get("SLURM_LOCALID", 0)
+    print(f"[init] Local Task ID: {local_id}")
+    print(f"[init] Computing config {args.config}")
+    print(f"[hint] To change config, use --config with A, B, C, or D")
+    SLURMID = str(32 * int(node_id) + int(local_id))
+
+    save_dir = "topologies"
     if not os.path.exists(save_dir):
         os.makedirs(save_dir)
 
     configA = {
-        'filename' : 'LONG_DEG2',
-        'line_num_bounds_0' : [4, 12],
-        'line_num_bounds_1' : [2, 12],
-        'MIN_DEGREE' : 2
+        "filename": "LONG_DEG2",
+        "line_num_bounds_0": [4, 12],
+        "line_num_bounds_1": [2, 12],
+        "MIN_DEGREE": 2,
     }
     configB = {
-        'filename' : 'SHORT_DEG2',
-        'line_num_bounds_0' : [4, 8],
-        'line_num_bounds_1' : [2, 6],
-        'MIN_DEGREE' : 2
+        "filename": "SHORT_DEG2",
+        "line_num_bounds_0": [4, 8],
+        "line_num_bounds_1": [2, 6],
+        "MIN_DEGREE": 2,
     }
     configC = {
-        'filename' : 'LONG_DEG1',
-        'line_num_bounds_0' : [4, 12],
-        'line_num_bounds_1' : [2, 12],
-        'MIN_DEGREE' : 1
+        "filename": "LONG_DEG1",
+        "line_num_bounds_0": [4, 12],
+        "line_num_bounds_1": [2, 12],
+        "MIN_DEGREE": 1,
     }
     configD = {
-        'filename' : 'SHORT_DEG1',
-        'line_num_bounds_0' : [4, 8],
-        'line_num_bounds_1' : [2, 6],
-        'MIN_DEGREE' : 1
+        "filename": "SHORT_DEG1",
+        "line_num_bounds_0": [4, 8],
+        "line_num_bounds_1": [2, 6],
+        "MIN_DEGREE": 1,
     }
 
-    configs = {
-        'A' : configA,
-        'B' : configB,
-        'C' : configC,
-        'D' : configD
-    }
-
+    configs = {"A": configA, "B": configB, "C": configC, "D": configD}
     config = configs[args.config]
 
     failed_at_loop = 0
     failed_at_degree = 0
     failed_at_pms = 0
+
     tt = time.time()
-    for i in range(1):
-        # tt = time.time()
+
+    for _ in range(1):
         valid = False
         num_tries = 0
+
         while not valid:
             num_tries += 1
-            if num_tries % 100000 == 0:
-                print(f'num_tries: {num_tries}')
-                # print(f'failed_at_loop: {failed_at_loop}')
-                # print(f'failed_at_degree: {failed_at_degree}')
-                # print(f'failed_at_pms: {failed_at_pms}')
-            num_lines_0 = np.random.randint(*(config['line_num_bounds_0']))
-            num_lines_1 = np.random.randint(*(config['line_num_bounds_1']))
+            if args.progress_every > 0 and num_tries % args.progress_every == 0:
+                total = max(1, num_tries)
+                loop_p = failed_at_loop / total * 100
+                deg_p = failed_at_degree / total * 100
+                pm_p = failed_at_pms / total * 100
+                print(
+                    f"[progress] attempts: {num_tries} | "
+                    f"failed(loop/deg/pm): {failed_at_loop}/{failed_at_degree}/{failed_at_pms} "
+                    f"({loop_p:.1f}%/{deg_p:.1f}%/{pm_p:.1f}%)"
+                )
 
-            #shape (num_lines_0, 2)
+            num_lines_0 = np.random.randint(*config["line_num_bounds_0"])
+            num_lines_1 = np.random.randint(*config["line_num_bounds_1"])
+
+            # shape (num_lines_0, 2) and (num_lines_1, 2)
             layer_0 = np.random.randint(len(val_verts_0), size=(num_lines_0, 2))
             layer_1 = np.random.randint(len(val_verts_1), size=(num_lines_1, 2))
 
-            #[28, 79, 85, 83]|[928, 123, 29, 141]
-            # layer_0 = [28, 79, 85, 83]
-            # layer_1 = [928, 123, 29, 141]
-
-            edge_num = []
+            # Validate for N in {0, 1, 2}
             for N, vertex_count in enumerate(VERTEX_NUMS):
-                # if N == 1:
-                #     print('N:', N)
-                # if N == 2:
-                #     print('N:', N)
-                #     #plot all graphs
-                #     for nn, vc in enumerate(VERTEX_NUMS):
-                #         gg = generate_graph(layer_0, layer_1, nn)
-                #         gg = [sorted(edge)+[0,0] for edge in gg]
-                #         plot_graph(gg, f'graph_{nn}.html')
                 gg = generate_graph(layer_0, layer_1, N)
                 gg = [sorted(edge) for edge in gg]
-                # check if self loops present
+
+                # 1) Self-loops
                 if not check_self_loops(gg):
-                    valid = False
                     failed_at_loop += 1
-                    break
-                if not check_degree_and_vertcount(gg,vertex_count, min_degree=config['MIN_DEGREE']):
+                    if args.verbose_invalid:
+                        print(f"[reject] N={N}: self-loop encountered")
                     valid = False
+                    break
+
+                # 2) Degree & vertex count
+                if not check_degree_and_vertcount(gg, vertex_count, min_degree=config["MIN_DEGREE"]):
                     failed_at_degree += 1
-                    break
-                if not check_pms(gg):
+                    if args.verbose_invalid:
+                        print(f"[reject] N={N}: degree/vertex-count check failed")
                     valid = False
-                    failed_at_pms += 1
                     break
-                valid = True
-        print('CODE FOUND')
-        #save layer_0, layer_1 to file
-        with open(os.path.join(save_dir, f"{config['filename']}.txt"), 'a') as f:
-            layer_0 = [list(edge) for edge in layer_0]
-            layer_1 = [list(edge) for edge in layer_1]
-            f.write(f'{layer_0}|{layer_1}\n')
 
-    print(f'time taken: {time.time()-tt} seconds')
+                # 3) Every edge in some perfect matching
+                if not check_pms(gg):
+                    failed_at_pms += 1
+                    if args.verbose_invalid:
+                        print(f"[reject] N={N}: edge not in any perfect matching")
+                    valid = False
+                    break
+
+                valid = True  # so far good for this N; overall valid if all N pass
+
+        print("[result] CODE FOUND")
+
+        # Save layer_0, layer_1 to file (append)
+        out_path = os.path.join(save_dir, f"{config['filename']}.txt")
+        with open(out_path, "a") as f:
+            layer_0_list = [list(edge) for edge in layer_0]
+            layer_1_list = [list(edge) for edge in layer_1]
+            f.write(f"{layer_0_list}|{layer_1_list}\n")
+
+    print(f"[done] time taken: {time.time() - tt:.3f} seconds")
+    print(f"[stats] attempts: {num_tries} | "
+          f"failed(loop/deg/pm): {failed_at_loop}/{failed_at_degree}/{failed_at_pms}")
+    print(f"[output] appended to: {out_path}")
 
 
+if __name__ == "__main__":
+    main()

--- a/data_main/generate_topologies.py
+++ b/data_main/generate_topologies.py
@@ -134,6 +134,12 @@ def main() -> None:
     parser.add_argument("--task_id", type=int, default=0, help="Task index for distributed runs.")
     parser.add_argument("--config", type=str, default="A", choices=list("ABCD"), help="Which config to use.")
     parser.add_argument(
+        "--num_tops",
+        type=int,
+        default=1,
+        help="Number of topologies to generate in this run (default: 1).",
+    )
+    parser.add_argument(
         "--verbose-invalid",
         action="store_true",
         help="If set, print reasons when a candidate graph is rejected.",
@@ -151,6 +157,7 @@ def main() -> None:
     print(f"[init] Local Task ID: {local_id}")
     print(f"[init] Computing config {args.config}")
     print(f"[hint] To change config, use --config with A, B, C, or D")
+    print(f"[init] Generating {args.num_tops} topologies")
     SLURMID = str(32 * int(node_id) + int(local_id))
 
     save_dir = "topologies"
@@ -191,7 +198,8 @@ def main() -> None:
 
     tt = time.time()
 
-    for _ in range(1):
+    NUM_TOPS = args.num_tops
+    for _ in range(NUM_TOPS):
         valid = False
         num_tries = 0
 


### PR DESCRIPTION
I am working fixing some dependency issues and cleaning up the code a bit.

I will soon expand this to the rest of the code and update `requirements.txt` when I've cleaned up the whole repo.

For now, here is how to create a virtual environment that can run `data_main/generate_topologies.py` and `data_main/generate_data.py`.

Tested on Python 3.11.9 on macOS.

**set up a local virtual environment and install dependencies**
```
python3.11 -m venv localvenv
source localvenv/bin/activate
python -m pip install --upgrade pip setuptools wheel
pip install pytheusQ==1.2.21
pip install h5py
```

**generate one topology for each configuration A, B, C, and D (for testing purposes, for real runs more topologies would be needed)**

I have also added
- some more instructive print outputs (showing what is being computed and the progress)
- some arguments that can be passed to the script from the command line (like `num_tops`)

```
python3.11 generate_topologies.py --config A --num_tops 1
python3.11 generate_topologies.py --config B --num_tops 1
python3.11 generate_topologies.py --config C --num_tops 1
python3.11 generate_topologies.py --config D --num_tops 1
```

**generate data based on the generated topologies**
```
python3.11 generate_data.py
```